### PR TITLE
Don't call 'clear' in the shell if running in GVim.

### DIFF
--- a/autoload/gtest.vim
+++ b/autoload/gtest.vim
@@ -60,8 +60,7 @@ function! s:GetTestNameFromFull(full)
 endfunction
 
 function! s:GetTestFullFromLine(line)
-  let l:result = substitute(a:line, '^TEST\s*(\s*\(\S\{-1,}\),\s*\(\S\{-1,}\)\s*).*$', '\1.\2', '')
-  return l:result 
+  return substitute(a:line, '^TEST\s*(\s*\(\S\{-1,}\),\s*\(\S\{-1,}\)\s*).*$', '\1.\2', '')
 endfunction
 
 function! gtest#ListTestCases(arg, line, pos)

--- a/autoload/gtest.vim
+++ b/autoload/gtest.vim
@@ -60,7 +60,8 @@ function! s:GetTestNameFromFull(full)
 endfunction
 
 function! s:GetTestFullFromLine(line)
-  return substitute(a:line, '^TEST.*(\(.*\), *\(.*\)).*$', '\1.\2', '')
+  let l:result = substitute(a:line, '^TEST\s*(\s*\(\S\{-1,}\),\s*\(\S\{-1,}\)\s*).*$', '\1.\2', '')
+  return l:result 
 endfunction
 
 function! gtest#ListTestCases(arg, line, pos)

--- a/autoload/gtest.vim
+++ b/autoload/gtest.vim
@@ -48,7 +48,11 @@ endfunction
 
 function! s:GetFullCommand()
   let l:cmd = g:gtest#gtest_command . " " . s:GetArguments()
-  return "( clear && " . l:cmd . ")"
+  if !has("gui_running")
+    return "( clear && " . l:cmd . ")"
+  else
+    return "(" . l:cmd . ")"
+  endif
 endfunction
 
 function! s:GetTestCaseFromFull(full)

--- a/autoload/gtest.vim
+++ b/autoload/gtest.vim
@@ -64,7 +64,9 @@ function! s:GetTestNameFromFull(full)
 endfunction
 
 function! s:GetTestFullFromLine(line)
-  return substitute(a:line, '^TEST.*(\(.*\), *\(.*\)).*$', '\1.\2', '')
+  l:result = substitute(a:line, '^TEST.*(\(.*\), *\(.*\)).*$', '\1.\2', '')
+  l:result = substitute(l:result, '^\s*\(.\{-}\)\s*$', '\1', '')
+  return l:result 
 endfunction
 
 function! gtest#ListTestCases(arg, line, pos)

--- a/autoload/gtest.vim
+++ b/autoload/gtest.vim
@@ -64,8 +64,7 @@ function! s:GetTestNameFromFull(full)
 endfunction
 
 function! s:GetTestFullFromLine(line)
-  l:result = substitute(a:line, '^TEST.*(\(.*\), *\(.*\)).*$', '\1.\2', '')
-  l:result = substitute(l:result, '^\s*\(.\{-}\)\s*$', '\1', '')
+  let l:result = substitute(a:line, '^TEST\s*(\s*\(\S\{-1,}\),\s*\(\S\{-1,}\)\s*).*$', '\1.\2', '')
   return l:result 
 endfunction
 


### PR DESCRIPTION
It is not necessary if running in a GUI.
