### PR TITLE
Strip whitespace from test name.

### DIFF
--- a/autoload/gtest.vim
+++ b/autoload/gtest.vim
@@ -60,8 +60,7 @@ function! s:GetTestNameFromFull(full)
 endfunction
 
 function! s:GetTestFullFromLine(line)
-  let l:result = substitute(a:line, '^TEST\s*(\s*\(\S\{-1,}\),\s*\(\S\{-1,}\)\s*).*$', '\1.\2', '')
-  return l:result 
+  return substitute(a:line, '^TEST\s*(\s*\(\S\{-1,}\),\s*\(\S\{-1,}\)\s*).*$', '\1.\2', '')
 endfunction
 
 function! gtest#ListTestCases(arg, line, pos)

--- a/autoload/gtest.vim
+++ b/autoload/gtest.vim
@@ -60,7 +60,8 @@ function! s:GetTestNameFromFull(full)
 endfunction
 
 function! s:GetTestFullFromLine(line)
-  return substitute(a:line, '^TEST.*(\(.*\), *\(.*\)).*$', '\1.\2', '')
+  let l:result = substitute(a:line, '^TEST\s*(\s*\(\S\{-1,}\),\s*\(\S\{-1,}\)\s*).*$', '\1.\2', '')
+  return l:result 
 endfunction
 
 function! gtest#ListTestCases(arg, line, pos)


### PR DESCRIPTION
I don't know regexes very well, so it maybe be wrong, but it works for me.
The previous code didn't parse this line well:
TEST( TestCase, TestName )
It produced " TestCase.TestName " instead of "TestCase.TestName".
