### PR TITLE
Correctly match TEST_F, TEST_P and similar constructs.

### DIFF
--- a/autoload/gtest.vim
+++ b/autoload/gtest.vim
@@ -64,7 +64,7 @@ function! s:GetTestNameFromFull(full)
 endfunction
 
 function! s:GetTestFullFromLine(line)
-  return substitute(a:line, '^TEST\s*(\s*\(\S\{-1,}\),\s*\(\S\{-1,}\)\s*).*$', '\1.\2', '')
+  return substitute(a:line, '^TEST.*(\s*\(\S\{-1,}\),\s*\(\S\{-1,}\)\s*).*$', '\1.\2', '')
 endfunction
 
 function! gtest#ListTestCases(arg, line, pos)


### PR DESCRIPTION
This was broken by 1086fc742e60fd78be90446de4fb29393ef5356b.

This fixes #13.