### PR TITLE
GTestJump should handle common test naming convention Fixes #17

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,16 +134,16 @@ You can map these commands to your favorite shortcuts. These are mine:
 
 ```
 augroup GTest
-  autocmd FileType cpp nnoremap <silent> <leader>tt :GTestRun<CR>
-  autocmd FileType cpp nnoremap <silent> <leader>tu :GTestRunUnderCursor<CR>
-  autocmd FileType cpp nnoremap          <leader>tc :GTestCase<space>
-  autocmd FileType cpp nnoremap          <leader>tn :GTestName<space>
-  autocmd FileType cpp nnoremap <silent> <leader>te :GTestToggleEnabled<CR>
-  autocmd FileType cpp nnoremap <silent> ]T         :GTestNext<CR>
-  autocmd FileType cpp nnoremap <silent> [T         :GTestPrev<CR>
-  autocmd FileType cpp nnoremap <silent> <leader>tf :CtrlPGTest<CR>
-  autocmd FileType cpp nnoremap <silent> <leader>tj :GTestJump<CR>
-  autocmd FileType cpp nnoremap          <leader>ti :GTestNewTest<CR>i
+	autocmd FileType cpp nnoremap <silent> <leader>tt :GTestRun<CR>
+	autocmd FileType cpp nnoremap <silent> <leader>tu :GTestRunUnderCursor<CR>
+	autocmd FileType cpp nnoremap          <leader>tc :GTestCase<space>
+	autocmd FileType cpp nnoremap          <leader>tn :GTestName<space>
+	autocmd FileType cpp nnoremap <silent> <leader>te :GTestToggleEnabled<CR>
+	autocmd FileType cpp nnoremap <silent> ]T         :GTestNext<CR>
+	autocmd FileType cpp nnoremap <silent> [T         :GTestPrev<CR>
+	autocmd FileType cpp nnoremap <silent> <leader>tf :CtrlPGTest<CR>
+	autocmd FileType cpp nnoremap <silent> <leader>tj :GTestJump<CR>
+	autocmd FileType cpp nnoremap          <leader>ti :GTestNewTest<CR>i
 augroup END
 ```
 

--- a/README.md
+++ b/README.md
@@ -115,11 +115,18 @@ You can switch from implementation to header to test:
 :GTestJump
 ```
 
-Filenames must follow this rule:
+By default, filenames must follow this rule:
 
  - implementation: `src/**/*.cpp`
  - header: `src/**/*.hpp`
  - test: `test/**/*_test.cpp`
+
+Test file suffix can be customized in vimrc using
+```
+let g:gtest#test_filename_suffix = "Test"
+```
+GTestJump will then look for test filename
+ - test: `test/**/*Test.cpp`
 
 ## Shortcuts
 
@@ -127,16 +134,16 @@ You can map these commands to your favorite shortcuts. These are mine:
 
 ```
 augroup GTest
-	autocmd FileType cpp nnoremap <silent> <leader>tt :GTestRun<CR>
-	autocmd FileType cpp nnoremap <silent> <leader>tu :GTestRunUnderCursor<CR>
-	autocmd FileType cpp nnoremap          <leader>tc :GTestCase<space>
-	autocmd FileType cpp nnoremap          <leader>tn :GTestName<space>
-	autocmd FileType cpp nnoremap <silent> <leader>te :GTestToggleEnabled<CR>
-	autocmd FileType cpp nnoremap <silent> ]T         :GTestNext<CR>
-	autocmd FileType cpp nnoremap <silent> [T         :GTestPrev<CR>
-	autocmd FileType cpp nnoremap <silent> <leader>tf :CtrlPGTest<CR>
-	autocmd FileType cpp nnoremap <silent> <leader>tj :GTestJump<CR>
-	autocmd FileType cpp nnoremap          <leader>ti :GTestNewTest<CR>i
+  autocmd FileType cpp nnoremap <silent> <leader>tt :GTestRun<CR>
+  autocmd FileType cpp nnoremap <silent> <leader>tu :GTestRunUnderCursor<CR>
+  autocmd FileType cpp nnoremap          <leader>tc :GTestCase<space>
+  autocmd FileType cpp nnoremap          <leader>tn :GTestName<space>
+  autocmd FileType cpp nnoremap <silent> <leader>te :GTestToggleEnabled<CR>
+  autocmd FileType cpp nnoremap <silent> ]T         :GTestNext<CR>
+  autocmd FileType cpp nnoremap <silent> [T         :GTestPrev<CR>
+  autocmd FileType cpp nnoremap <silent> <leader>tf :CtrlPGTest<CR>
+  autocmd FileType cpp nnoremap <silent> <leader>tj :GTestJump<CR>
+  autocmd FileType cpp nnoremap          <leader>ti :GTestNewTest<CR>i
 augroup END
 ```
 

--- a/autoload/gtest.vim
+++ b/autoload/gtest.vim
@@ -23,6 +23,9 @@ endif
 if !exists('g:gtest#highlight_failing_tests')
   let g:gtest#highlight_failing_tests = 0
 endif
+if !exists('g:gtest#test_filename_suffix')
+    let g:gtest#test_filename_suffix = '_test'
+endif
 " }}}
 
 " Private functions {{{

--- a/autoload/gtest/jump.vim
+++ b/autoload/gtest/jump.vim
@@ -6,12 +6,14 @@
 fu! s:GetBasename(path)
   let l:res = fnamemodify(a:path, ':r')
   let l:res = substitute(l:res, "^\[^/\]*/", "", "")
-  return substitute(l:res, "_test$", "", "")
+  let l:fns = g:gtest#test_filename_suffix
+  return substitute(l:res, l:fns . "$", "", "")
 endf
 
 fun! s:GetTestPath(path)
+  let l:fns = g:gtest#test_filename_suffix
   let l:base = s:GetBasename(a:path)
-  return "test/" . l:base . "_test.cpp"
+  return "test/" . l:base . l:fns . ".cpp"
 endf
 
 fun! s:GetHeaderPath(path)
@@ -25,7 +27,8 @@ fun! s:GetImplementationPath(path)
 endf
 
 fu! s:GetFileType(path)
-  if match(a:path, "_test.cpp$") != -1
+  let l:fns = g:gtest#test_filename_suffix
+  if match(a:path, l:fns . ".cpp$") != -1
     return 1
   elseif match(a:path, ".cpp$") != -1
     return 2
@@ -39,6 +42,7 @@ endf
 " src/<name>.cpp
 " src/<name>.hpp
 " test/<name>_test.cpp
+" Test file suffix '_test' can be customized using g:gtest#test_filename_suffix
 "
 fu! gtest#jump#FileJump()
   let l:path = expand("%")


### PR DESCRIPTION
Hi,

Within this change the test filename suffix can be customized in users vimrc.
```vim
let g:gtest#test_filename_suffix = "Test"
```

Cheers,
Mo