### PR TITLE
Narrower filter for parameterized tests

### DIFF
--- a/autoload/gtest.vim
+++ b/autoload/gtest.vim
@@ -70,7 +70,7 @@ function! s:GetTestFilterFromLine(line)
   let l:ms = matchlist(a:line, '^\(TEST\S*\)\s*(\s*\(\S\{-1,}\),\s*\(\S\{-1,}\)\s*).*$')
 
   if l:ms[1] == 'TEST_P'
-      return '*' . l:ms[2] . '.' . l:ms[3] . '*'
+      return '*/' . l:ms[2] . '.' . l:ms[3] . '/*'
   else
       return l:ms[2] . '.' . l:ms[3]
   endif


### PR DESCRIPTION
The handling of parameterized tests introduced in `7fb016c794f` was not
narrow enough. With a parameterized test `Foo.Bar` under the under the
cursor it would not only match e.g., `0/Foo.Bar/0` but also
`0/LeFoo.Bar/0` or `0/Foo.BarBaz/0`.

With this patch we explicitly include the slashes in the generated
filter expression (e.g., filter for `*/Foo.Bar/*` instead of
`*Foo.Bar*`).