### PR TITLE
feature: added support form tslime.vim

### DIFF
--- a/autoload/gtest.vim
+++ b/autoload/gtest.vim
@@ -236,6 +236,9 @@ function! gtest#GTestRun()
     endif
 
     call VimuxRunCommand(l:cmd)
+  " Try with the tslime.vim plugin
+  elseif exists(':Tmux')
+    call Send_to_Tmux(l:cmd . "\n")
   else
     if g:gtest#highlight_failing_tests
       call gtest#highlight#StartListening()


### PR DESCRIPTION
This pr enable support for tslime.vim, which allows you to send the gtest command to a tmux pane.