### PR TITLE
fix bug in gtest#GTestRun()

### DIFF
--- a/autoload/gtest.vim
+++ b/autoload/gtest.vim
@@ -230,7 +230,7 @@ function! gtest#GTestRun()
   elseif exists(':Dispatch')
     call s:RunWithDispatch(l:cmd, g:gtest#highlight_failing_tests)
   " Try with VimuxRunCommand
-  elseif exists('VimuxRunCommand')
+  elseif exists(':VimuxRunCommand')
     if g:gtest#highlight_failing_tests
       call gtest#highlight#StartListening()
     endif


### PR DESCRIPTION
`exists('VimuxRunCommand')` misses a `:` and it always returns 0.